### PR TITLE
Only allow project names that have letters, numbers and hyphens

### DIFF
--- a/src/create-twilio-function.js
+++ b/src/create-twilio-function.js
@@ -1,4 +1,8 @@
-const { promptForAccountDetails } = require('./create-twilio-function/prompt');
+const {
+  promptForAccountDetails,
+  promptForProjectName,
+  nameRegex
+} = require('./create-twilio-function/prompt');
 const {
   createDirectory,
   createEnvFile,
@@ -28,6 +32,10 @@ async function cleanUpAndExit(projectDir, spinner, errorMessage) {
 }
 
 async function createTwilioFunction(config) {
+  if (!config.name.match(nameRegex)) {
+    const { name } = await promptForProjectName();
+    config.name = name;
+  }
   const projectDir = path.join(config.path, config.name);
   const spinner = ora();
 

--- a/src/create-twilio-function.js
+++ b/src/create-twilio-function.js
@@ -1,8 +1,8 @@
 const {
   promptForAccountDetails,
-  promptForProjectName,
-  nameRegex
+  promptForProjectName
 } = require('./create-twilio-function/prompt');
+const validateProjectName = require('./create-twilio-function/validate-project-name');
 const {
   createDirectory,
   createEnvFile,
@@ -32,8 +32,9 @@ async function cleanUpAndExit(projectDir, spinner, errorMessage) {
 }
 
 async function createTwilioFunction(config) {
-  if (!config.name.match(nameRegex)) {
-    const { name } = await promptForProjectName();
+  const { valid, errors } = validateProjectName(config.name);
+  if (!valid) {
+    const { name } = await promptForProjectName(errors);
     config.name = name;
   }
   const projectDir = path.join(config.path, config.name);

--- a/src/create-twilio-function/prompt.js
+++ b/src/create-twilio-function/prompt.js
@@ -1,20 +1,11 @@
 const inquirer = require('inquirer');
+const validateProjectName = require('./validate-project-name');
 
 function validateAccountSid(input) {
   if (input.startsWith('AC') || input === '') {
     return true;
   } else {
     return 'An Account SID starts with "AC".';
-  }
-}
-
-const nameRegex = /^[A-Za-z0-9\-]+$/;
-
-function validateProjectName(input) {
-  if (!input.match(nameRegex)) {
-    return 'Project name has invalid characters.';
-  } else {
-    return true;
   }
 }
 
@@ -39,14 +30,19 @@ async function promptForAccountDetails(config) {
   return await inquirer.prompt(questions);
 }
 
-async function promptForProjectName() {
+async function promptForProjectName(errors) {
   const questions = [
     {
       type: 'input',
       name: 'name',
-      message:
-        'Project names may only include the characters A-Z, a-z, 0-9 and _. Please choose a new project name.',
-      validate: validateProjectName
+      message: `Project names ${errors.join(
+        ', '
+      )}. Please choose a new project name.`,
+      validate: name => {
+        const { valid, errors } = validateProjectName(name);
+        if (valid) return valid;
+        return `Project ${errors.join(', ')}.`;
+      }
     }
   ];
   return await inquirer.prompt(questions);
@@ -55,7 +51,5 @@ async function promptForProjectName() {
 module.exports = {
   promptForAccountDetails,
   promptForProjectName,
-  validateAccountSid,
-  validateProjectName,
-  nameRegex
+  validateAccountSid
 };

--- a/src/create-twilio-function/prompt.js
+++ b/src/create-twilio-function/prompt.js
@@ -8,6 +8,16 @@ function validateAccountSid(input) {
   }
 }
 
+const nameRegex = /^[A-Za-z0-9\-]+$/;
+
+function validateProjectName(input) {
+  if (!input.match(nameRegex)) {
+    return 'Project name has invalid characters.';
+  } else {
+    return true;
+  }
+}
+
 async function promptForAccountDetails(config) {
   if (config.skipCredentials) return {};
   const questions = [];
@@ -16,9 +26,7 @@ async function promptForAccountDetails(config) {
       type: 'input',
       name: 'accountSid',
       message: 'Twilio Account SID',
-      validate: input => {
-        return validateAccountSid(input);
-      }
+      validate: validateAccountSid
     });
   }
   if (typeof config.authToken === 'undefined') {
@@ -31,4 +39,23 @@ async function promptForAccountDetails(config) {
   return await inquirer.prompt(questions);
 }
 
-module.exports = { promptForAccountDetails };
+async function promptForProjectName() {
+  const questions = [
+    {
+      type: 'input',
+      name: 'name',
+      message:
+        'Project names may only include the characters A-Z, a-z, 0-9 and _. Please choose a new project name.',
+      validate: validateProjectName
+    }
+  ];
+  return await inquirer.prompt(questions);
+}
+
+module.exports = {
+  promptForAccountDetails,
+  promptForProjectName,
+  validateAccountSid,
+  validateProjectName,
+  nameRegex
+};

--- a/src/create-twilio-function/validate-project-name.js
+++ b/src/create-twilio-function/validate-project-name.js
@@ -1,0 +1,40 @@
+function validateProjectName(name) {
+  let valid = true;
+  const errors = [];
+  if (!assertNotLongerThan(name, 32)) {
+    valid = false;
+    errors.push('must be shorter than 32 characters');
+  }
+  if (!assertContainsLettersNumbersHyphens(name)) {
+    valid = false;
+    errors.push('must only include letters, numbers and hyphens');
+  }
+  if (!assertDoesntStartWithHyphen(name)) {
+    valid = false;
+    errors.push('must not start with a hyphen');
+  }
+  if (!assertDoesntEndWithHyphen(name)) {
+    valid = false;
+    errors.push('must not end with a hyphen');
+  }
+  return { valid, errors };
+}
+
+function assertContainsLettersNumbersHyphens(name) {
+  const nameRegex = /^[A-Za-z0-9\-]+$/;
+  return !!name.match(nameRegex);
+}
+
+function assertDoesntStartWithHyphen(name) {
+  return !name.startsWith('-');
+}
+
+function assertDoesntEndWithHyphen(name) {
+  return !name.endsWith('-');
+}
+
+function assertNotLongerThan(name, chars = 32) {
+  return name.length <= chars;
+}
+
+module.exports = validateProjectName;

--- a/tests/create-twilio-function.test.js
+++ b/tests/create-twilio-function.test.js
@@ -52,205 +52,266 @@ afterEach(async () => {
 });
 
 describe('createTwilioFunction', () => {
-  beforeEach(() => {
-    inquirer.prompt = jest.fn(() =>
-      Promise.resolve({
-        accountSid: 'test-sid',
-        authToken: 'test-auth-token'
-      })
-    );
+  describe('with an acceptable project name', () => {
+    beforeEach(() => {
+      inquirer.prompt = jest.fn(() =>
+        Promise.resolve({
+          accountSid: 'test-sid',
+          authToken: 'test-auth-token'
+        })
+      );
 
-    nock('https://raw.githubusercontent.com')
-      .get('/github/gitignore/master/Node.gitignore')
-      .reply(200, '*.log\n.env');
-  });
+      nock('https://raw.githubusercontent.com')
+        .get('/github/gitignore/master/Node.gitignore')
+        .reply(200, '*.log\n.env');
+    });
 
-  it('scaffolds a Twilio Function', async () => {
-    const name = 'test-function';
-    await createTwilioFunction({ name, path: './scratch' });
+    it('scaffolds a Twilio Function', async () => {
+      const name = 'test-function';
+      await createTwilioFunction({ name, path: './scratch' });
 
-    const dir = await stat(`./scratch/${name}`);
-    expect(dir.isDirectory());
-    const env = await stat(`./scratch/${name}/.env`);
-    expect(env.isFile());
-    const nvmrc = await stat(`./scratch/${name}/.nvmrc`);
-    expect(nvmrc.isFile());
+      const dir = await stat(`./scratch/${name}`);
+      expect(dir.isDirectory());
+      const env = await stat(`./scratch/${name}/.env`);
+      expect(env.isFile());
+      const nvmrc = await stat(`./scratch/${name}/.nvmrc`);
+      expect(nvmrc.isFile());
 
-    const packageJSON = await stat(`./scratch/${name}/package.json`);
-    expect(packageJSON.isFile());
+      const packageJSON = await stat(`./scratch/${name}/package.json`);
+      expect(packageJSON.isFile());
 
-    const gitignore = await stat(`./scratch/${name}/.gitignore`);
-    expect(gitignore.isFile());
+      const gitignore = await stat(`./scratch/${name}/.gitignore`);
+      expect(gitignore.isFile());
 
-    const functions = await stat(`./scratch/${name}/functions`);
-    expect(functions.isDirectory());
+      const functions = await stat(`./scratch/${name}/functions`);
+      expect(functions.isDirectory());
 
-    const assets = await stat(`./scratch/${name}/assets`);
-    expect(assets.isDirectory());
+      const assets = await stat(`./scratch/${name}/assets`);
+      expect(assets.isDirectory());
 
-    const example = await stat(`./scratch/${name}/functions/hello-world.js`);
-    expect(example.isFile());
+      const example = await stat(`./scratch/${name}/functions/hello-world.js`);
+      expect(example.isFile());
 
-    const asset = await stat(`./scratch/${name}/assets/index.html`);
-    expect(asset.isFile());
+      const asset = await stat(`./scratch/${name}/assets/index.html`);
+      expect(asset.isFile());
 
-    expect(installDependencies).toHaveBeenCalledWith(`scratch/${name}`);
+      expect(installDependencies).toHaveBeenCalledWith(`scratch/${name}`);
 
-    expect(console.log).toHaveBeenCalledWith('success message');
-  });
+      expect(console.log).toHaveBeenCalledWith('success message');
+    });
 
-  it('scaffolds a Twilio Function with a template', async () => {
-    const gitHubAPI = nock('https://api.github.com');
-    gitHubAPI
-      .get('/repos/twilio-labs/function-templates/contents/blank')
-      .reply(200, [
-        {
-          name: 'functions'
-        },
-        {
-          name: '.env',
-          download_url:
-            'https://raw.githubusercontent.com/twilio-labs/function-templates/master/blank/.env'
-        }
-      ]);
-    gitHubAPI
-      .get('/repos/twilio-labs/function-templates/contents/blank/functions')
-      .reply(200, [
-        {
-          name: 'blank.js',
-          download_url:
-            'https://raw.githubusercontent.com/twilio-labs/function-templates/master/blank/functions/blank.js'
-        }
-      ]);
-    const gitHubRaw = nock('https://raw.githubusercontent.com');
-    gitHubRaw
-      .get('/twilio-labs/function-templates/master/blank/functions/blank.js')
-      .reply(
-        200,
-        `exports.handler = function(context, event, callback) {
+    it('scaffolds a Twilio Function with a template', async () => {
+      const gitHubAPI = nock('https://api.github.com');
+      gitHubAPI
+        .get('/repos/twilio-labs/function-templates/contents/blank')
+        .reply(200, [
+          {
+            name: 'functions'
+          },
+          {
+            name: '.env',
+            download_url:
+              'https://raw.githubusercontent.com/twilio-labs/function-templates/master/blank/.env'
+          }
+        ]);
+      gitHubAPI
+        .get('/repos/twilio-labs/function-templates/contents/blank/functions')
+        .reply(200, [
+          {
+            name: 'blank.js',
+            download_url:
+              'https://raw.githubusercontent.com/twilio-labs/function-templates/master/blank/functions/blank.js'
+          }
+        ]);
+      const gitHubRaw = nock('https://raw.githubusercontent.com');
+      gitHubRaw
+        .get('/twilio-labs/function-templates/master/blank/functions/blank.js')
+        .reply(
+          200,
+          `exports.handler = function(context, event, callback) {
   callback(null, {});
 };`
+        );
+      gitHubRaw
+        .get('/github/gitignore/master/Node.gitignore')
+        .reply(200, 'node_modules/');
+      gitHubRaw
+        .get('/twilio-labs/function-templates/master/blank/.env')
+        .reply(200, '');
+
+      const name = 'test-function';
+      await createTwilioFunction({
+        name,
+        path: './scratch',
+        template: 'blank'
+      });
+
+      const dir = await stat(`./scratch/${name}`);
+      expect(dir.isDirectory());
+      const env = await stat(`./scratch/${name}/.env`);
+      expect(env.isFile());
+      const nvmrc = await stat(`./scratch/${name}/.nvmrc`);
+      expect(nvmrc.isFile());
+
+      const packageJSON = await stat(`./scratch/${name}/package.json`);
+      expect(packageJSON.isFile());
+
+      const gitignore = await stat(`./scratch/${name}/.gitignore`);
+      expect(gitignore.isFile());
+
+      const functions = await stat(`./scratch/${name}/functions`);
+      expect(functions.isDirectory());
+
+      const assets = await stat(`./scratch/${name}/assets`);
+      expect(assets.isDirectory());
+
+      const exampleFiles = await readdir(`./scratch/${name}/functions`);
+      expect(exampleFiles).toEqual(
+        expect.not.arrayContaining(['hello-world.js'])
       );
-    gitHubRaw
-      .get('/github/gitignore/master/Node.gitignore')
-      .reply(200, 'node_modules/');
-    gitHubRaw
-      .get('/twilio-labs/function-templates/master/blank/.env')
-      .reply(200, '');
 
-    const name = 'test-function';
-    await createTwilioFunction({
-      name,
-      path: './scratch',
-      template: 'blank'
+      const templateFunction = await stat(
+        `./scratch/${name}/functions/blank.js`
+      );
+      expect(templateFunction.isFile());
+
+      const exampleAssets = await readdir(`./scratch/${name}/assets`);
+      expect(exampleAssets).toEqual(expect.not.arrayContaining(['index.html']));
+
+      expect(installDependencies).toHaveBeenCalledWith(`scratch/${name}`);
+
+      expect(console.log).toHaveBeenCalledWith('success message');
     });
 
-    const dir = await stat(`./scratch/${name}`);
-    expect(dir.isDirectory());
-    const env = await stat(`./scratch/${name}/.env`);
-    expect(env.isFile());
-    const nvmrc = await stat(`./scratch/${name}/.nvmrc`);
-    expect(nvmrc.isFile());
+    it('handles a missing template gracefully', async () => {
+      const templateName = 'missing';
+      const name = 'test-function';
+      const gitHubAPI = nock('https://api.github.com');
+      gitHubAPI
+        .get(`/repos/twilio-labs/function-templates/contents/${templateName}`)
+        .reply(404);
 
-    const packageJSON = await stat(`./scratch/${name}/package.json`);
-    expect(packageJSON.isFile());
+      const fail = jest.spyOn(spinner, 'fail');
 
-    const gitignore = await stat(`./scratch/${name}/.gitignore`);
-    expect(gitignore.isFile());
+      await createTwilioFunction({
+        name,
+        path: './scratch',
+        template: templateName
+      });
 
-    const functions = await stat(`./scratch/${name}/functions`);
-    expect(functions.isDirectory());
+      expect.assertions(3);
 
-    const assets = await stat(`./scratch/${name}/assets`);
-    expect(assets.isDirectory());
-
-    const exampleFiles = await readdir(`./scratch/${name}/functions`);
-    expect(exampleFiles).toEqual(
-      expect.not.arrayContaining(['hello-world.js'])
-    );
-
-    const templateFunction = await stat(`./scratch/${name}/functions/blank.js`);
-    expect(templateFunction.isFile());
-
-    const exampleAssets = await readdir(`./scratch/${name}/assets`);
-    expect(exampleAssets).toEqual(expect.not.arrayContaining(['index.html']));
-
-    expect(installDependencies).toHaveBeenCalledWith(`scratch/${name}`);
-
-    expect(console.log).toHaveBeenCalledWith('success message');
-  });
-
-  it('handles a missing template gracefully', async () => {
-    const templateName = 'missing';
-    const name = 'test-function';
-    const gitHubAPI = nock('https://api.github.com');
-    gitHubAPI
-      .get(`/repos/twilio-labs/function-templates/contents/${templateName}`)
-      .reply(404);
-
-    const fail = jest.spyOn(spinner, 'fail');
-
-    await createTwilioFunction({
-      name,
-      path: './scratch',
-      template: templateName
+      expect(fail).toHaveBeenCalledTimes(1);
+      expect(fail).toHaveBeenCalledWith(
+        `The template "${templateName}" doesn't exist`
+      );
+      try {
+        await stat(`./scratch/${name}`);
+      } catch (e) {
+        expect(e.toString()).toMatch('no such file or directory');
+      }
     });
 
-    expect.assertions(3);
+    it("doesn't scaffold if the target folder name already exists", async () => {
+      const name = 'test-function';
+      await mkdir('./scratch/test-function');
+      const fail = jest.spyOn(spinner, 'fail');
 
-    expect(fail).toHaveBeenCalledTimes(1);
-    expect(fail).toHaveBeenCalledWith(
-      `The template "${templateName}" doesn't exist`
-    );
-    try {
-      await stat(`./scratch/${name}`);
-    } catch (e) {
-      expect(e.toString()).toMatch('no such file or directory');
-    }
+      await createTwilioFunction({ name, path: './scratch' });
+
+      expect.assertions(4);
+
+      expect(fail).toHaveBeenCalledTimes(1);
+      expect(fail).toHaveBeenCalledWith(
+        `A directory called '${name}' already exists. Please create your function in a new directory.`
+      );
+      expect(console.log).not.toHaveBeenCalled();
+
+      try {
+        await stat(`./scratch/${name}/package.json`);
+      } catch (e) {
+        expect(e.toString()).toMatch('no such file or directory');
+      }
+    });
+
+    it("fails gracefully if it doesn't have permission to create directories", async () => {
+      const name = 'test-function';
+      const chmod = promisify(fs.chmod);
+      await chmod('./scratch', 0o555);
+      const fail = jest.spyOn(spinner, 'fail');
+
+      await createTwilioFunction({ name, path: './scratch' });
+
+      expect.assertions(4);
+
+      expect(fail).toHaveBeenCalledTimes(1);
+      expect(fail).toHaveBeenCalledWith(
+        `You do not have permission to create files or directories in the path './scratch'.`
+      );
+      expect(console.log).not.toHaveBeenCalled();
+
+      try {
+        await stat(`./scratch/${name}/package.json`);
+      } catch (e) {
+        expect(e.toString()).toMatch('no such file or directory');
+      }
+    });
   });
 
-  it("doesn't scaffold if the target folder name already exists", async () => {
-    const name = 'test-function';
-    await mkdir('./scratch/test-function');
-    const fail = jest.spyOn(spinner, 'fail');
+  describe('with an unacceptable project name', () => {
+    beforeEach(() => {
+      inquirer.prompt = jest.fn();
+      inquirer.prompt
+        .mockReturnValueOnce(
+          Promise.resolve({
+            name: 'test-function'
+          })
+        )
+        .mockReturnValueOnce(
+          Promise.resolve({
+            accountSid: 'test-sid',
+            authToken: 'test-auth-token'
+          })
+        );
 
-    await createTwilioFunction({ name, path: './scratch' });
+      nock('https://raw.githubusercontent.com')
+        .get('/github/gitignore/master/Node.gitignore')
+        .reply(200, '*.log\n.env');
+    });
 
-    expect.assertions(4);
+    it('scaffolds a Twilio Function and prompts for a new name', async () => {
+      const badName = 'GreatTest!!!';
+      const name = 'test-function';
+      await createTwilioFunction({ name: badName, path: './scratch' });
 
-    expect(fail).toHaveBeenCalledTimes(1);
-    expect(fail).toHaveBeenCalledWith(
-      `A directory called '${name}' already exists. Please create your function in a new directory.`
-    );
-    expect(console.log).not.toHaveBeenCalled();
+      const dir = await stat(`./scratch/${name}`);
+      expect(dir.isDirectory());
+      const env = await stat(`./scratch/${name}/.env`);
+      expect(env.isFile());
+      const nvmrc = await stat(`./scratch/${name}/.nvmrc`);
+      expect(nvmrc.isFile());
 
-    try {
-      await stat(`./scratch/${name}/package.json`);
-    } catch (e) {
-      expect(e.toString()).toMatch('no such file or directory');
-    }
-  });
+      const packageJSON = await stat(`./scratch/${name}/package.json`);
+      expect(packageJSON.isFile());
 
-  it("fails gracefully if it doesn't have permission to create directories", async () => {
-    const name = 'test-function';
-    const chmod = promisify(fs.chmod);
-    await chmod('./scratch', 0o555);
-    const fail = jest.spyOn(spinner, 'fail');
+      const gitignore = await stat(`./scratch/${name}/.gitignore`);
+      expect(gitignore.isFile());
 
-    await createTwilioFunction({ name, path: './scratch' });
+      const functions = await stat(`./scratch/${name}/functions`);
+      expect(functions.isDirectory());
 
-    expect.assertions(4);
+      const assets = await stat(`./scratch/${name}/assets`);
+      expect(assets.isDirectory());
 
-    expect(fail).toHaveBeenCalledTimes(1);
-    expect(fail).toHaveBeenCalledWith(
-      `You do not have permission to create files or directories in the path './scratch'.`
-    );
-    expect(console.log).not.toHaveBeenCalled();
+      const example = await stat(`./scratch/${name}/functions/hello-world.js`);
+      expect(example.isFile());
 
-    try {
-      await stat(`./scratch/${name}/package.json`);
-    } catch (e) {
-      expect(e.toString()).toMatch('no such file or directory');
-    }
+      const asset = await stat(`./scratch/${name}/assets/index.html`);
+      expect(asset.isFile());
+
+      expect(installDependencies).toHaveBeenCalledWith(`scratch/${name}`);
+
+      expect(console.log).toHaveBeenCalledWith('success message');
+    });
   });
 });

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -1,7 +1,26 @@
 const {
-  promptForAccountDetails
+  validateAccountSid,
+  promptForAccountDetails,
+  validateProjectName,
+  promptForProjectName
 } = require('../src/create-twilio-function/prompt');
 const inquirer = require('inquirer');
+
+describe('accountSid validation', () => {
+  test('an accountSid should start with "AC"', () => {
+    expect(validateAccountSid('AC123')).toBe(true);
+  });
+
+  test('an accountSid can be left blank', () => {
+    expect(validateAccountSid('')).toBe(true);
+  });
+
+  test('an accountSid should not begin with anything but "AC"', () => {
+    expect(validateAccountSid('blah')).toEqual(
+      'An Account SID starts with "AC".'
+    );
+  });
+});
 
 describe('promptForAccountDetails', () => {
   test(`should ask for an accountSid if not specified`, async () => {
@@ -48,11 +67,37 @@ describe('promptForAccountDetails', () => {
     expect(inquirer.prompt).toHaveBeenCalledWith([]);
   });
 
-  test(`should not ask for credentials if skip-credentials flag is true`, async () => {
+  test('should not ask for credentials if skip-credentials flag is true', async () => {
     inquirer.prompt = jest.fn(() => {});
     await promptForAccountDetails({
       skipCredentials: true
     });
     expect(inquirer.prompt).not.toHaveBeenCalled();
+  });
+});
+
+describe('validating project name', () => {
+  test('a project name can contain capitals, lowercase, numbers and hyphens', () => {
+    expect(validateProjectName('An-ok-ProjectName123')).toBe(true);
+  });
+
+  test('a project name cannot contain anything else', () => {
+    const expectedError = 'Project name has invalid characters.';
+    expect(validateProjectName('not_ok')).toBe(expectedError);
+    expect(validateProjectName('Spaces are not allowed')).toBe(expectedError);
+    expect(validateProjectName('#')).toBe(expectedError);
+  });
+});
+
+describe('promptForProjectName', () => {
+  test('should ask for a project name', async () => {
+    inquirer.prompt = jest.fn(() =>
+      Promise.resolve({
+        name: 'test-name'
+      })
+    );
+    await promptForProjectName();
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+    expect(inquirer.prompt).toHaveBeenCalledWith(expect.any(Array));
   });
 });

--- a/tests/prompt.test.js
+++ b/tests/prompt.test.js
@@ -1,7 +1,6 @@
 const {
   validateAccountSid,
   promptForAccountDetails,
-  validateProjectName,
   promptForProjectName
 } = require('../src/create-twilio-function/prompt');
 const inquirer = require('inquirer');
@@ -76,19 +75,6 @@ describe('promptForAccountDetails', () => {
   });
 });
 
-describe('validating project name', () => {
-  test('a project name can contain capitals, lowercase, numbers and hyphens', () => {
-    expect(validateProjectName('An-ok-ProjectName123')).toBe(true);
-  });
-
-  test('a project name cannot contain anything else', () => {
-    const expectedError = 'Project name has invalid characters.';
-    expect(validateProjectName('not_ok')).toBe(expectedError);
-    expect(validateProjectName('Spaces are not allowed')).toBe(expectedError);
-    expect(validateProjectName('#')).toBe(expectedError);
-  });
-});
-
 describe('promptForProjectName', () => {
   test('should ask for a project name', async () => {
     inquirer.prompt = jest.fn(() =>
@@ -96,7 +82,7 @@ describe('promptForProjectName', () => {
         name: 'test-name'
       })
     );
-    await promptForProjectName();
+    await promptForProjectName(['must be valid']);
     expect(inquirer.prompt).toHaveBeenCalledTimes(1);
     expect(inquirer.prompt).toHaveBeenCalledWith(expect.any(Array));
   });

--- a/tests/validate-project-name.test.js
+++ b/tests/validate-project-name.test.js
@@ -1,0 +1,50 @@
+const validateProjectName = require('../src/create-twilio-function/validate-project-name');
+
+describe('validateProjectName', () => {
+  it('should allow names shorter than 33 characters', () => {
+    const { valid } = validateProjectName('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(valid).toBe(true);
+  });
+
+  it('should disallow names longer than 32 characters', () => {
+    const { valid, errors } = validateProjectName(
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+    expect(valid).toBe(false);
+    expect(errors[0]).toEqual('must be shorter than 32 characters');
+  });
+
+  it('should allow names with letters, numbers and hyphens', () => {
+    const { valid } = validateProjectName('Project-1');
+    expect(valid).toBe(true);
+  });
+
+  it('should disallow names with special characters or underscores', () => {
+    const names = ['project!', 'project@', '#hello', '__hey'];
+    names.forEach(name => {
+      const { valid, errors } = validateProjectName(name);
+      expect(valid).toBe(false);
+      expect(errors[0]).toEqual(
+        'must only include letters, numbers and hyphens'
+      );
+    });
+  });
+
+  it('should disallow names beginning with a hyphen', () => {
+    const { valid, errors } = validateProjectName('-otherwisecool');
+    expect(valid).toBe(false);
+    expect(errors[0]).toBe('must not start with a hyphen');
+  });
+
+  it('should disallow names ending with a hyphen', () => {
+    const { valid, errors } = validateProjectName('otherwisecool-');
+    expect(valid).toBe(false);
+    expect(errors[0]).toBe('must not end with a hyphen');
+  });
+
+  it('should return multiple messages if there are multiple errors', () => {
+    const { valid, errors } = validateProjectName('-not#Cool-');
+    expect(valid).toBe(false);
+    expect(errors.length).toBe(3);
+  });
+});


### PR DESCRIPTION
In [twilio-run#71](https://github.com/twilio-labs/twilio-run/issues/71) we discovered that projects with underscores in can't be deployed. 

This PR stops you creating a project name with anything but letters, numbers and hyphens.

Need to find out if there are more rules for project names before fully merging this.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
