### PR TITLE
window-size module with getWindowSize function

### DIFF
--- a/src/create-twilio-function/success-message.js
+++ b/src/create-twilio-function/success-message.js
@@ -1,6 +1,6 @@
 const { getPackageManager } = require('pkg-install');
 const chalk = require('chalk');
-const windowSize = require('window-size');
+const getWindowSize = require('./window-size');
 const wrap = require('wrap-ansi');
 
 async function successMessage(config) {
@@ -20,7 +20,7 @@ Get started by running:
 
 {blue cd ${config.name}}
 {blue ${packageManager} start}`,
-    windowSize.get().width - 8,
+    getWindowSize().width - 8,
     { trim: false, hard: true }
   );
 }

--- a/src/create-twilio-function/window-size.js
+++ b/src/create-twilio-function/window-size.js
@@ -1,0 +1,17 @@
+const windowSize = require('window-size');
+
+function getWindowSize() {
+  const defaultSize = { width: 80, height: 300 };
+  let currentSize = windowSize.get();
+
+  if (!currentSize) {
+    return defaultSize;
+  }
+  else {
+    if(!currentSize.width) currentSize.width = defaultSize.width;
+    if(!currentSize.height) currentSize.height = defaultSize.height;
+    return currentSize;
+  }
+}
+
+module.exports = getWindowSize;

--- a/tests/window-size.test.js
+++ b/tests/window-size.test.js
@@ -1,0 +1,33 @@
+const getWindowSize = require('../src/create-twilio-function/window-size');
+
+jest.mock('window-size', () => ({ get: jest
+    .fn()
+    .mockReturnValueOnce({ width: 40, height: 100 })
+    .mockReturnValueOnce()
+    .mockReturnValueOnce({ height: 250 })
+    .mockReturnValueOnce({ width: 50 })
+    .mockReturnValueOnce({ width: 80, height: 300 })
+    }));
+
+describe('getWindowSize', () => {
+  it('gets a valid windowSize', () => {
+    const windowSize = getWindowSize();
+    expect(windowSize).toEqual({ width: 40, height: 100 });
+  });
+  it('cannot get a null windowSize', () => {
+    const windowSize = getWindowSize();
+    expect(windowSize).toEqual({ width: 80, height: 300 });
+  });
+  it('gets a windowSize without a width', () => {
+    const windowSize = getWindowSize();
+    expect(windowSize).toEqual({ width: 80, height: 250 });
+  });
+  it('gets a windowSize without a height', () => {
+    const windowSize = getWindowSize();
+    expect(windowSize).toEqual({ width: 50, height: 300 });
+  });
+  it('gets a windowSize without a width nor a height', () => {
+    const windowSize = getWindowSize();
+    expect(windowSize).toEqual({ width: 80, height: 300 });
+  });
+});


### PR DESCRIPTION
getWindowSize checks the returned size and provides default values for invalid values.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
