### PR TITLE
Allows passing --empty option to not generate template files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,32 +86,32 @@ This works with any of the other ways of calling `create-twilio-function`. Check
 ## Command line arguments
 
 ```
-create-twilio-function <name>
-
 Creates a new Twilio Function project
 
 Commands:
-  create-twilio-function <name>          Creates a new Twilio Function
-                                         project                    [default]
-  create-twilio-function list-templates  List the available templates you can
-                                         create a project with.
+  create-twilio-function <name>          Creates a new Twilio Function project
+                                                                       [default]
+  create-twilio-function list-templates  Lists the available Twilio Function
+                                         templates
 
 Positionals:
-  name  Name of your project.                                        [string]
+  name  Name of your project.                                           [string]
 
 Options:
-  --account-sid, -a     The Account SID for your Twilio account      [string]
-  --auth-token, -t      Your Twilio account Auth Token               [string]
-  --skip-credentials    Don't ask for Twilio account credentials or import
-                        them from the environment  [boolean] [default: false]
+  --account-sid, -a     The Account SID for your Twilio account         [string]
+  --auth-token, -t      Your Twilio account Auth Token                  [string]
+  --skip-credentials    Don't ask for Twilio account credentials or import them
+                        from the environment          [boolean] [default: false]
   --import-credentials  Import credentials from the environment variables
                         TWILIO_ACCOUNT_SID and TWILIO_AUTH_TOKEN
-                                                   [boolean] [default: false]
+                                                      [boolean] [default: false]
   --template            Initialize your new project with a template from
-                        github.com/twilio-labs/function-templates    [string]
-  -h, --help            Show help                                   [boolean]
-  -v, --version         Show version number                         [boolean]
-  --path                                                     [default: (cwd)]
+                        github.com/twilio-labs/function-templates       [string]
+  --empty               Initialize your new project with empty functions and
+                        assets directories            [boolean] [default: false]
+  -h, --help            Show help                                      [boolean]
+  -v, --version         Show version number                            [boolean]
+  --path                                                        [default: (cwd)]
 ```
 
 ## Contributing

--- a/src/command.js
+++ b/src/command.js
@@ -29,6 +29,11 @@ const cliInfo = {
       describe: 'Initialize your new project with a template from github.com/twilio-labs/function-templates',
       type: 'string',
     },
+    empty: {
+      describe: 'Initialize your new project with empty functions and assets directories',
+      type: 'boolean',
+      default: false,
+    },
   },
 };
 

--- a/src/create-twilio-function.js
+++ b/src/create-twilio-function.js
@@ -61,6 +61,16 @@ async function createTwilioFunction(config) {
     return;
   }
 
+  // Check to see if the request is valid for a template or an empty project
+  if (config.empty && config.template) {
+    await cleanUpAndExit(
+      projectDir,
+      spinner,
+      'You cannot scaffold an empty Functions project with a template. Please choose empty or a template.',
+    );
+    return;
+  }
+
   // Get account sid and auth token
   let accountDetails = await importCredentials(config);
   if (Object.keys(accountDetails).length === 0) {
@@ -88,6 +98,9 @@ async function createTwilioFunction(config) {
       await cleanUpAndExit(projectDir, spinner, `The template "${config.template}" doesn't exist`);
       return;
     }
+  } else if (config.empty) {
+    await createDirectory(projectDir, 'functions');
+    await createDirectory(projectDir, 'assets');
   } else {
     await createExampleFromTemplates(projectDir);
   }


### PR DESCRIPTION
If `--empty` and a `--template` is passed, the command will stop early with an error message.

Fixes #53.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
